### PR TITLE
aws: set default region to allow generation of HCL

### DIFF
--- a/terraform/aws/provider.tf
+++ b/terraform/aws/provider.tf
@@ -10,4 +10,6 @@ provider "aws" {
 }
 variable "access_key" {}
 variable "secret_key" {}
-variable "aws_region" {}
+variable "aws_region" {
+  default = "eu-west-1"
+}


### PR DESCRIPTION
If the terraform doesn't have the region set, it wouldn't be able to be
properly generated/calculated.