### PR TITLE
[AWS] Add password to cycloid user and enable password authentication

### DIFF
--- a/terraform/aws/module-aws/userdata.sh.tpl
+++ b/terraform/aws/module-aws/userdata.sh.tpl
@@ -1,16 +1,21 @@
 #cloud-config
-ssh_pwauth: True ## This line enables ssh password authentication
 users:
   - default
   - name: cycloid
     primary_group: cycloid
     groups: sudo
+    sudo: ['ALL=(ALL) NOPASSWD:ALL']
     lock_passwd: false
+    shell: /bin/bash
 
-# Using chpasswd module instead of password field in previous users one because
-# we want to generate a random password using Terraform. And unfortunatly generating a mkpasswd
-# is not possible
-chpasswd:
-    list: |
-        cycloid:${password}
-    expire: False
+cloud_config_modules:
+  - runcmd
+
+cloud_final_modules:
+  - scripts-user
+
+# Enabled tunneled clear text passwords, DO NOT use it in production. Only for testing purpose
+runcmd:
+  - (echo '${password}'; echo '${password}') | passwd cycloid # Change the password of the cycloid user
+  - sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
+  - systemctl restart ssh

--- a/terraform/aws/module-aws/vm.tf
+++ b/terraform/aws/module-aws/vm.tf
@@ -28,19 +28,11 @@ resource "random_string" "password" {
   override_special = "_%@"
 }
 
-data "template_file" "user_data" {
-  template = file("${path.module}/userdata.sh.tpl")
-
-  vars = {
-    password = random_string.password.result
-    env      = var.env
-    project  = var.project
-  }
-}
-
 resource "aws_instance" "front" {
   ami                         = data.aws_ami.debian.id
-  user_data_base64            = base64encode(data.template_file.user_data.rendered)
+  user_data                   =  templatefile("${path.module}/userdata.sh.tpl", {
+    password = random_string.password.result
+  })
   associate_public_ip_address = true
   instance_type               = var.instance_type
   vpc_security_group_ids      = [aws_security_group.front.id]


### PR DESCRIPTION
Hello,

For the AWS part I found that we cannot authenticate with the cycloid user when the instance is created.

I suspect some bugs or limitation for the cloud-init/cloud-config part. In fact, after many tests the *chpasswd* and *ssh_pwauth* modules doesn't seems to work.

So, I founded a way to bypass theses modules via the *runcmd* module.

Also, for the template, I used the [templatefile](https://www.terraform.io/docs/language/functions/templatefile.html) function available since Terraform 0.12 to greatly simplify the call

Finally I added a better shell to the cycloid user, and I allowed him to authenticate as root without having to enter a password. Maybe this part will have to be changed.

**Now, everything seems to work** 

![image](https://user-images.githubusercontent.com/23166349/132179593-be2a0c2c-94fc-4282-9bd5-d429d13024a3.png)

