### PR TITLE
aws: change owner account id

### DIFF
--- a/terraform/aws/module-aws/ami.tf
+++ b/terraform/aws/module-aws/ami.tf
@@ -21,5 +21,5 @@ data "aws_ami" "debian" {
     values = ["ebs"]
   }
 
-  owners = ["101072000470"] # Debian
+  owners = ["136693071363"] # Debian
 }

--- a/terraform/aws/module-aws/ami.tf
+++ b/terraform/aws/module-aws/ami.tf
@@ -3,7 +3,7 @@ data "aws_ami" "debian" {
 
   filter {
     name   = "name"
-    values = ["debian-10-amd64-*"]
+    values = ["debian-11-amd64-*"]
   }
 
   filter {
@@ -21,5 +21,15 @@ data "aws_ami" "debian" {
     values = ["ebs"]
   }
 
-  owners = ["136693071363"] # Debian
+  owners = [
+    "379101102735",
+    "136693071363",
+    "125523088429",
+    "099720109477",
+  ]
+
+  #"379101102735", # Old debian
+  #"136693071363", # Debian10 & debian11
+  #"125523088429", # Centos
+  #"099720109477", # Ubuntu
 }


### PR DESCRIPTION
## Description

Error during the execution of the getting started stack with the AWS use-case:

![image](https://user-images.githubusercontent.com/23166349/224819657-c01fe823-7bef-4105-9166-2ebdd38d1a14.png)

This PR changes the account ID to the correct one indicated [here](https://wiki.debian.org/Cloud/AmazonEC2Image/Buster).